### PR TITLE
Update compatible_devices[] array

### DIFF
--- a/src/jailbreak.c
+++ b/src/jailbreak.c
@@ -64,6 +64,7 @@ typedef struct _compatibility {
 
 compatibility_t compatible_devices[] = {
     {"N81AP", "10B400"},
+    {"N81AP", "10B500"},
 
     {"N41AP", "10B350"},
     {"N42AP", "10B350"},
@@ -75,6 +76,7 @@ compatibility_t compatible_devices[] = {
     {"N92AP", "10B329"},
     {"N81AP", "10B329"},
     {"N88AP", "10B329"},
+    {"N88AP", "10B500"},
 
     {"N78AP", "10B329"},
 


### PR DESCRIPTION
Added support for N81AP and N88AP (iPhone 3GS & iPod Touch 4G) on 10B500 (6.1.6).
